### PR TITLE
fix: handle null in GetNegativeColor

### DIFF
--- a/src/utils/GetNegativeColor.test.ts
+++ b/src/utils/GetNegativeColor.test.ts
@@ -1,0 +1,12 @@
+import { GetNegativeColor } from './GetNegativeColor';
+
+describe('GetNegativeColor', () => {
+  it('returns opposite color for white and black', () => {
+    expect(GetNegativeColor('white')).toBe('black');
+    expect(GetNegativeColor('black')).toBe('white');
+  });
+
+  it('returns null for null input', () => {
+    expect(GetNegativeColor(null)).toBeNull();
+  });
+});

--- a/src/utils/GetNegativeColor.ts
+++ b/src/utils/GetNegativeColor.ts
@@ -1,3 +1,7 @@
-export const GetNegativeColor = (color: 'white' | 'black' | null) => {
-    return color === 'white' ? 'black' : 'white'
+export const GetNegativeColor = (
+  color: 'white' | 'black' | null,
+): 'white' | 'black' | null => {
+  if (color === 'white') return 'black'
+  if (color === 'black') return 'white'
+  return null
 }


### PR DESCRIPTION
## Summary
- ensure `GetNegativeColor` returns `null` when given `null`
- add unit tests for `GetNegativeColor`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f0197d748322af0403d2ed9a5bfa