### PR TITLE
fix: handle null color and animate piece movement

### DIFF
--- a/src/components/ChessPiece/ChessPiece.tsx
+++ b/src/components/ChessPiece/ChessPiece.tsx
@@ -11,6 +11,7 @@ export const ChessPiece = ({
   type,
   isAttacking,
   isMoving,
+  moveKey,
   isHit,
   isDead,
   color,
@@ -22,6 +23,7 @@ export const ChessPiece = ({
   const currentAnimation = useChessPieceState({
     isAttacking,
     isMoving,
+    moveKey,
     isHit,
     isDead,
     isSelected,

--- a/src/components/ChessPiece/hooks/useChessPieceState.tsx
+++ b/src/components/ChessPiece/hooks/useChessPieceState.tsx
@@ -4,33 +4,44 @@ import { ChessPieceProps } from "../types";
 export const useChessPieceState = ({
   isAttacking,
   isMoving,
+  moveKey,
   isHit,
   isDead,
   isSelected,
 }: Pick<
   ChessPieceProps,
-  "isAttacking" | "isMoving" | "isHit" | "isDead" | "isSelected"
+  "isAttacking" | "isMoving" | "moveKey" | "isHit" | "isDead" | "isSelected"
 >) => {
   const [currentAnimation, setCurrentAnimation] = useState<
     "idle" | "walk" | "attack" | "hit" | "death" | "selected"
   >(isDead ? "death" : "idle");
 
-  const timeoutToIdle = useCallback(() => {
+  const timeoutToIdle = useCallback((duration = 100) => {
     setTimeout(() => {
       setCurrentAnimation("idle");
-    }, 100);
+    }, duration);
   }, []);
 
   useEffect(() => {
     if (isDead) setCurrentAnimation("death");
     else if (isAttacking) setCurrentAnimation("attack");
-    else if (isMoving) setCurrentAnimation("walk");
-    else if (isHit) setCurrentAnimation("hit");
+    else if (isMoving) {
+      setCurrentAnimation("walk");
+      timeoutToIdle(300);
+    } else if (isHit) setCurrentAnimation("hit");
     else if (isSelected) {
       setCurrentAnimation("selected");
       timeoutToIdle();
     } else setCurrentAnimation("idle");
-  }, [isAttacking, isMoving, isHit, isDead, isSelected, timeoutToIdle]);
+  }, [
+    isAttacking,
+    isMoving,
+    moveKey,
+    isHit,
+    isDead,
+    isSelected,
+    timeoutToIdle,
+  ]);
 
   return currentAnimation;
 };

--- a/src/components/ChessPiece/types.ts
+++ b/src/components/ChessPiece/types.ts
@@ -16,6 +16,7 @@ export interface ChessPieceProps {
   className?: string;
   isAttacking?: boolean;
   isMoving?: boolean;
+  moveKey?: string;
   isHit?: boolean;
   isDead?: boolean;
   isSelected?: boolean;

--- a/src/utils/GetNegativeColor.test.ts
+++ b/src/utils/GetNegativeColor.test.ts
@@ -1,0 +1,12 @@
+import { GetNegativeColor } from './GetNegativeColor';
+
+describe('GetNegativeColor', () => {
+  it('returns opposite color for white and black', () => {
+    expect(GetNegativeColor('white')).toBe('black');
+    expect(GetNegativeColor('black')).toBe('white');
+  });
+
+  it('returns null for null input', () => {
+    expect(GetNegativeColor(null)).toBeNull();
+  });
+});

--- a/src/utils/GetNegativeColor.ts
+++ b/src/utils/GetNegativeColor.ts
@@ -1,3 +1,7 @@
-export const GetNegativeColor = (color: 'white' | 'black' | null) => {
-    return color === 'white' ? 'black' : 'white'
+export const GetNegativeColor = (
+  color: 'white' | 'black' | null,
+): 'white' | 'black' | null => {
+  if (color === 'white') return 'black'
+  if (color === 'black') return 'white'
+  return null
 }


### PR DESCRIPTION
## Summary
- ensure `GetNegativeColor` returns `null` when given `null`
- add unit tests for `GetNegativeColor`
- detect piece movement to trigger walk animation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5f0197d748322af0403d2ed9a5bfa